### PR TITLE
Adds in an endpoint to get the user details without a password.

### DIFF
--- a/src/main/java/net/smartcosmos/userdetails/resource/ActiveResource.java
+++ b/src/main/java/net/smartcosmos/userdetails/resource/ActiveResource.java
@@ -1,0 +1,40 @@
+package net.smartcosmos.userdetails.resource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import net.smartcosmos.annotation.SmartCosmosRdao;
+import net.smartcosmos.userdetails.service.AuthenticateUserService;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+
+import static net.smartcosmos.userdetails.util.ResponseEntityFactory.invalidUsernameOrPassword;
+
+@SmartCosmosRdao
+public class ActiveResource {
+
+    private final AuthenticateUserService service;
+
+    @Autowired
+    public ActiveResource(AuthenticateUserService authenticateUserService) {
+
+        service = authenticateUserService;
+    }
+
+    @RequestMapping(value = "active/{username}",
+                    produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<?> authenticate(@PathVariable("username") String username) {
+
+        return service.isUserActive(username);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> invalidRequest() {
+
+        return invalidUsernameOrPassword();
+    }
+}

--- a/src/main/java/net/smartcosmos/userdetails/service/AuthenticateUserService.java
+++ b/src/main/java/net/smartcosmos/userdetails/service/AuthenticateUserService.java
@@ -16,4 +16,6 @@ public interface AuthenticateUserService {
      * @return the response entity
      */
     ResponseEntity<?> authenticateUser(AuthenticateRequest request);
+
+    ResponseEntity<?> isUserActive(String username);
 }

--- a/src/main/java/net/smartcosmos/userdetails/service/AuthenticateUserServiceDefault.java
+++ b/src/main/java/net/smartcosmos/userdetails/service/AuthenticateUserServiceDefault.java
@@ -46,4 +46,25 @@ public class AuthenticateUserServiceDefault implements AuthenticateUserService {
             return invalidUsernameOrPassword();
         }
     }
+
+    @Override
+    public ResponseEntity<?> isUserActive(String username) {
+
+        log.debug("Requested information on username {} ", username, username);
+
+        try {
+            UserDetails userDetails = userDetailsService.getUserDetails(username);
+
+            if (userDetails != null) {
+                log.info("Validation of authentication response for user {} : valid", username);
+                return success(userDetails);
+            }
+
+            log.info("Validation of authentication response for user {} : invalid", username);
+            return invalidDataReturned();
+        } catch (AuthenticationException e) {
+            log.info("Authenticating user {} failed (no longer active?). Exception: {}", username, e.toString());
+            return invalidUsernameOrPassword();
+        }
+    }
 }

--- a/src/main/java/net/smartcosmos/userdetails/service/UserDetailsService.java
+++ b/src/main/java/net/smartcosmos/userdetails/service/UserDetailsService.java
@@ -22,6 +22,17 @@ public interface UserDetailsService {
     UserDetails getUserDetails(String username, String password) throws IllegalArgumentException, AuthenticationException;
 
     /**
+     * Gets the user details without a password, which is necessary to support refresh tokens.
+     *
+     * @param username the user name
+     * @return the User Details
+     * @throws IllegalArgumentException f {@code username} is {@code null} or empty
+     * @throws AuthenticationException  if something goes wrong and the details can't be returned, e.g., the user does not exist or the credentials
+     *                                  are incorrect
+     */
+    UserDetails getUserDetails(String username) throws IllegalArgumentException, AuthenticationException;
+
+    /**
      * Verifies that the User Details don't violate any constraints, i.e. it contains all required fields.
      *
      * @param userDetails the User Details.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a new endpoint to user details services called `/active/{username}` this will allow checking the updated users details and authorities for a refresh token.

#### Depends On

This will be required before the Auth server fixes can be merged in.

